### PR TITLE
fix(core): various auth fixes

### DIFF
--- a/examples/blog/.env.example
+++ b/examples/blog/.env.example
@@ -1,11 +1,13 @@
-# MongoDB
+### MongoDB
 MONGODB_URI=mongodb://localhost/catalyst-blog-example
 
-# Next Auth
-NEXTAUTH_SECRET="SOME-SECRET-HERE" # this can be any random unguessable string
-NEXTAUTH_URL="http://localhost:3000" # points to the nextjs instance i.e. localhost in dev and actual domain in production
+### Next Auth
+# this can be any random unguessable string
+NEXTAUTH_SECRET="SOME-SECRET-HERE"
+# points to the nextjs instance i.e. localhost in dev and actual domain in production
+NEXTAUTH_URL="http://localhost:3000"
 
-# Google OAuth
+### Google OAuth
 # Note: hit me up if you want to use my google oauth credentials for dev
 GOOGLE_CLIENT_ID="some-google-oauth-id"
 GOOGLE_CLIENT_SECRET="some-google-oauth-secret"

--- a/packages/catalyst/src/auth.ts
+++ b/packages/catalyst/src/auth.ts
@@ -23,6 +23,12 @@ const authOptions: AuthOptions = {
       const doc = await collection.findOne({ email: user.email });
 
       if (!doc) {
+        const userCount = await collection.estimatedDocumentCount();
+
+        // Allow first user to sign in without
+        // being part of the users collection.
+        if (userCount === 0) return true;
+
         return false;
       }
 
@@ -43,6 +49,6 @@ export function isAuthRequest(req: NextApiRequest) {
 
 export function createCatalystAuthObject() {
   return {
-    getServerSession: () => getServerSession(authOptions),
+    getSession: () => getServerSession(authOptions),
   };
 }

--- a/packages/catalyst/src/components/auth/SignInWIthGoogle.tsx
+++ b/packages/catalyst/src/components/auth/SignInWIthGoogle.tsx
@@ -9,7 +9,7 @@ export const SignInWithGoogle: React.FC = () => {
 
   return (
     <Button
-      onClick={() => signInWithGoogle(subroute)}
+      onClick={() => signInWithGoogle(`/${subroute}`)}
       className="!bg-red-600 px-4 hover:bg-red-700"
     >
       Sign in with Google

--- a/packages/catalyst/src/index.ts
+++ b/packages/catalyst/src/index.ts
@@ -1,5 +1,5 @@
 import { UserCatalystConfig } from "./types";
-import { createRootPage } from "./pages";
+import { createRootPage } from "./pages/base";
 import { createCatalystAuthObject } from "./auth";
 import { createCatalystDataObject } from "./data";
 import { createRootEndpoint } from "./endpoints";

--- a/packages/catalyst/src/pages/base.tsx
+++ b/packages/catalyst/src/pages/base.tsx
@@ -1,55 +1,124 @@
-import { CatalystAuth, CatalystConfig } from "../types";
-import { redirect } from "next/navigation";
-import { Logo } from "../components/Logo";
-import { CurrentSubrouteLink } from "../components/CurrentSubrouteLink";
+import "@unocss/reset/tailwind-compat.css";
+import "./uno.css";
+import { notFound, redirect } from "next/navigation";
+import { CatalystAuth, CatalystConfig, CatalystDataObject } from "../types";
+import { IndexPage } from ".";
+import { BrowsePage } from "./browse";
+import { CreatePage } from "./create";
+import { EditCollectionPage } from "./editCollection";
+import LoginPage from "./login";
+import LogoutPage from "./logout";
+import { EditGlobalPage } from "./editGlobal";
 
-type IndexPageProps = {
-  config: CatalystConfig;
-  auth: CatalystAuth;
+type RootPageProps = {
+  params: {
+    catalyst?: string[];
+  };
+  searchParams?: Record<string, string>;
 };
 
-export async function IndexPage({ config, auth }: IndexPageProps) {
-  const session = await auth.getServerSession();
+export function createRootPage<C extends CatalystConfig>(
+  config: C,
+  data: CatalystDataObject<C>,
+  auth: CatalystAuth
+) {
+  return async function RootPage({ params, searchParams }: RootPageProps) {
+    if (params.catalyst && params.catalyst[0] === "login") {
+      // @ts-expect-error Server Components
+      return <LoginPage />;
+    }
 
-  if (!session) {
-    redirect("/catalyst/login");
-  }
+    const session = await auth.getSession();
 
-  return (
-    <div className="flex flex-col bg-gray-100 p-16 h-full gap-4">
-      <div className="flex items-center gap-2 mb-8">
-        <Logo className="w-11 h-11" />
-        <h1 className="text-red-600 font-black text-4xl">CATALYST</h1>
-      </div>
+    if (!session) {
+      redirect("/catalyst/login");
+    }
 
-      <div className="flex flex-col">
-        <span className="font-semibold text-gray-500 mb-1">Collections</span>
-        <div className="flex flex-col gap-2">
-          {Object.entries(config.collections).map(([key, collection]) => (
-            <CurrentSubrouteLink
-              key={key}
-              href={`browse/${key}`}
-              className="p-4 flex flex-col gap-4 font-semibold text-gray-700 border border-gray-300 rounded bg-white hover:border-gray-400"
-            >
-              {collection.label}
-            </CurrentSubrouteLink>
-          ))}
-        </div>
-      </div>
-      <div className="flex flex-col">
-        <span className="font-semibold text-gray-500 mb-1">Globals</span>
-        <div className="flex flex-col gap-2">
-          {Object.entries(config.globals).map(([key, global]) => (
-            <CurrentSubrouteLink
-              key={key}
-              href={`edit/${key}`}
-              className="p-4 flex flex-col gap-4 font-semibold text-gray-700 border border-gray-300 rounded bg-white hover:border-gray-400"
-            >
-              {global.label}
-            </CurrentSubrouteLink>
-          ))}
-        </div>
-      </div>
-    </div>
-  );
+    if (!params.catalyst) {
+      // @ts-expect-error Server Components
+      return <IndexPage config={config} auth={auth} />;
+    }
+
+    const [route] = params.catalyst;
+
+    if (route === "browse") {
+      const collectionName = params.catalyst[1];
+
+      const collection = config.collections[collectionName];
+
+      if (!collection) {
+        notFound();
+      }
+
+      return (
+        // @ts-expect-error Server Components
+        <BrowsePage
+          collection={{ ...collection, name: collectionName }}
+          data={data}
+        />
+      );
+    } else if (route === "create") {
+      const collectionName = params.catalyst[1];
+
+      const collection = config.collections[collectionName];
+
+      if (!collection) {
+        notFound();
+      }
+
+      return (
+        // @ts-expect-error Server Components
+        <CreatePage
+          collection={collection}
+          name={collectionName}
+          i18n={config.i18n}
+        />
+      );
+    } else if (route === "edit") {
+      const [_, typeName, docId] = params.catalyst;
+
+      const collection = config.collections[typeName];
+
+      if (collection) {
+        return (
+          // @ts-expect-error server components
+          <EditCollectionPage
+            collection={collection}
+            data={data}
+            searchParams={searchParams}
+            i18n={config.i18n}
+            name={typeName}
+            docId={docId}
+          />
+        );
+      }
+
+      const global = config.globals[typeName];
+
+      if (!global) {
+        notFound();
+      }
+
+      return (
+        // @ts-expect-error Server Components
+        <EditGlobalPage
+          global={global}
+          data={data}
+          searchParams={searchParams}
+          i18n={config.i18n}
+          name={typeName}
+        />
+      );
+    } else if (route === "login") {
+      return (
+        // @ts-expect-error Server Components
+        <LoginPage />
+      );
+    } else if (route === "logout") {
+      // @ts-expect-error Server Components
+      return <LogoutPage />;
+    }
+
+    notFound();
+  };
 }

--- a/packages/catalyst/src/pages/editGlobal.tsx
+++ b/packages/catalyst/src/pages/editGlobal.tsx
@@ -5,7 +5,6 @@ import type {
 } from "../types";
 import { Form } from "../components/form/Form";
 import { getFormFieldsFromDataType } from "../components/form/utils";
-import { getPreviewUrlForDoc } from "../preview";
 
 type Props<C extends CatalystConfig> = {
   i18n: C["i18n"];
@@ -35,7 +34,7 @@ export async function EditGlobalPage<C extends CatalystConfig>({
       endpoint={`/api/global/${name}`}
       submitText={doc ? "Update" : "Create"}
       title={`EDIT ${name}`}
-      previewUrl={previewUrl && getPreviewUrlForDoc(doc, previewUrl)}
+      previewUrl={previewUrl}
       typeName={name as string}
     />
   );

--- a/packages/catalyst/src/pages/index.tsx
+++ b/packages/catalyst/src/pages/index.tsx
@@ -1,113 +1,48 @@
-import "@unocss/reset/tailwind-compat.css";
-import "./uno.css";
-import { notFound } from "next/navigation";
-import { CatalystAuth, CatalystConfig, CatalystDataObject } from "../types";
-import { IndexPage } from "./base";
-import { BrowsePage } from "./browse";
-import { CreatePage } from "./create";
-import { EditCollectionPage } from "./editCollection";
-import LoginPage from "./login";
-import LogoutPage from "./logout";
-import { EditGlobalPage } from "./editGlobal";
+import { CatalystAuth, CatalystConfig } from "../types";
+import { Logo } from "../components/Logo";
+import { CurrentSubrouteLink } from "../components/CurrentSubrouteLink";
 
-type RootPageProps = {
-  params: {
-    catalyst?: string[];
-  };
-  searchParams?: Record<string, string>;
+type IndexPageProps = {
+  config: CatalystConfig;
+  auth: CatalystAuth;
 };
 
-export function createRootPage<C extends CatalystConfig>(
-  config: C,
-  data: CatalystDataObject<C>,
-  auth: CatalystAuth
-) {
-  return async function RootPage({ params, searchParams }: RootPageProps) {
-    if (!params.catalyst) {
-      // @ts-expect-error Server Components
-      return <IndexPage config={config} auth={auth} />;
-    }
+export async function IndexPage({ config, auth }: IndexPageProps) {
+  return (
+    <div className="flex flex-col bg-gray-100 p-16 h-full gap-4">
+      <div className="flex items-center gap-2 mb-8">
+        <Logo className="w-11 h-11" />
+        <h1 className="text-red-600 font-black text-4xl">CATALYST</h1>
+      </div>
 
-    const [route] = params.catalyst;
-
-    if (route === "browse") {
-      const collectionName = params.catalyst[1];
-
-      const collection = config.collections[collectionName];
-
-      if (!collection) {
-        notFound();
-      }
-
-      return (
-        // @ts-expect-error Server Components
-        <BrowsePage
-          collection={{ ...collection, name: collectionName }}
-          data={data}
-        />
-      );
-    } else if (route === "create") {
-      const collectionName = params.catalyst[1];
-
-      const collection = config.collections[collectionName];
-
-      if (!collection) {
-        notFound();
-      }
-
-      return (
-        // @ts-expect-error Server Components
-        <CreatePage
-          collection={collection}
-          name={collectionName}
-          i18n={config.i18n}
-        />
-      );
-    } else if (route === "edit") {
-      const [_, typeName, docId] = params.catalyst;
-
-      const collection = config.collections[typeName];
-
-      if (collection) {
-        return (
-          // @ts-expect-error server components
-          <EditCollectionPage
-            collection={collection}
-            data={data}
-            searchParams={searchParams}
-            i18n={config.i18n}
-            name={typeName}
-            docId={docId}
-          />
-        );
-      }
-
-      const global = config.globals[typeName];
-
-      if (!global) {
-        notFound();
-      }
-
-      return (
-        // @ts-expect-error Server Components
-        <EditGlobalPage
-          global={global}
-          data={data}
-          searchParams={searchParams}
-          i18n={config.i18n}
-          name={typeName}
-        />
-      );
-    } else if (route === "login") {
-      return (
-        // @ts-expect-error Server Components
-        <LoginPage />
-      );
-    } else if (route === "logout") {
-      // @ts-expect-error Server Components
-      return <LogoutPage />;
-    }
-
-    notFound();
-  };
+      <div className="flex flex-col">
+        <span className="font-semibold text-gray-500 mb-1">Collections</span>
+        <div className="flex flex-col gap-2">
+          {Object.entries(config.collections).map(([key, collection]) => (
+            <CurrentSubrouteLink
+              key={key}
+              href={`browse/${key}`}
+              className="p-4 flex flex-col gap-4 font-semibold text-gray-700 border border-gray-300 rounded bg-white hover:border-gray-400"
+            >
+              {collection.label}
+            </CurrentSubrouteLink>
+          ))}
+        </div>
+      </div>
+      <div className="flex flex-col">
+        <span className="font-semibold text-gray-500 mb-1">Globals</span>
+        <div className="flex flex-col gap-2">
+          {Object.entries(config.globals).map(([key, global]) => (
+            <CurrentSubrouteLink
+              key={key}
+              href={`edit/${key}`}
+              className="p-4 flex flex-col gap-4 font-semibold text-gray-700 border border-gray-300 rounded bg-white hover:border-gray-400"
+            >
+              {global.label}
+            </CurrentSubrouteLink>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
 }


### PR DESCRIPTION
This PR fixes some auth-related issues:
- Google sign in redirect URL was incorrect
- Blog example used invalid comments in the `.env.example` file
- We now allow the first user to bypass the `users` collection whitelist check
- Fixed all redirects for auth-protected pages