### PR TITLE
feat(dashboard):Added toast creating/updating types

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -4,5 +4,6 @@
   "tabWidth": 2,
   "semi": true,
   "arrowParens": "avoid",
-  "endOfLine": "auto"
+  "endOfLine": "auto",
+  "plugins": ["prettier-plugin-tailwindcss"]
 }

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   "devDependencies": {
     "concurrently": "^8.0.1",
     "prettier": "^2.8.8",
+    "prettier-plugin-tailwindcss": "^0.2.8",
     "turbo": "latest"
   },
   "packageManager": "pnpm@8.3.1"

--- a/packages/catalyst/package.json
+++ b/packages/catalyst/package.json
@@ -25,6 +25,7 @@
     "next-auth": "^4.22.1",
     "react-error-boundary": "^4.0.4",
     "react-hook-form": "^7.43.9",
+    "react-toastify": "^9.1.2",
     "wretch": "^2.5.2"
   },
   "peerDependencies": {

--- a/packages/catalyst/src/dashboard/_shared/Toast/Toast.tsx
+++ b/packages/catalyst/src/dashboard/_shared/Toast/Toast.tsx
@@ -1,0 +1,46 @@
+import {
+  Icon,
+  IconAlertCircle,
+  IconCircleCheck,
+  IconCircleX,
+  IconInfoCircle
+} from "@tabler/icons-react";
+import { ToastType } from "./types";
+import clsx from "clsx";
+
+const toastTypeStyleMap: Record<ToastType, string> = {
+  error: "text-red-500",
+  success: "text-green-500",
+  warning: "text-yellow-500",
+  info: "text-blue-500"
+};
+
+const toastIconMap: Record<ToastType, Icon> = {
+  success: IconCircleCheck,
+  error: IconCircleX,
+  info: IconInfoCircle,
+  warning: IconAlertCircle
+};
+
+export type ToastProps = {
+  type: ToastType;
+  title: string;
+};
+
+export const Toast: React.FC<ToastProps> = ({ title, type }) => {
+  const selectedStyle = toastTypeStyleMap[type];
+  const SelectedToastIcon = toastIconMap[type];
+  return (
+    <div className="flex items-center gap-2 rounded-md   drop-shadow-lg">
+      <div
+        className={clsx(
+          "w-100 flex content-center items-center gap-2 text-lg text-black ",
+          selectedStyle
+        )}
+      >
+        <SelectedToastIcon />
+        {title}
+      </div>
+    </div>
+  );
+};

--- a/packages/catalyst/src/dashboard/_shared/Toast/ToastProvider.tsx
+++ b/packages/catalyst/src/dashboard/_shared/Toast/ToastProvider.tsx
@@ -1,0 +1,8 @@
+"use client";
+
+import { ToastContainer } from "react-toastify";
+import "react-toastify/dist/ReactToastify.css";
+
+export const ToastProvider: React.FC = () => {
+  return <ToastContainer />;
+};

--- a/packages/catalyst/src/dashboard/_shared/Toast/types.ts
+++ b/packages/catalyst/src/dashboard/_shared/Toast/types.ts
@@ -1,0 +1,1 @@
+export type ToastType = "success" | "error" | "warning" | "info";

--- a/packages/catalyst/src/dashboard/components/form/Form.tsx
+++ b/packages/catalyst/src/dashboard/components/form/Form.tsx
@@ -10,6 +10,7 @@ import { useMemo } from "react";
 import { FormField } from "./types";
 import clsx from "clsx";
 import { getObjectWithDepopulatedReferences } from "./utils";
+import { useToast } from "../../hooks/useToast";
 
 type Props = {
   fields: FormField[];
@@ -33,10 +34,10 @@ export const Form: React.FC<Props> = ({
   title,
   previewUrl,
   i18n,
-  typeName,
+  typeName
 }) => {
   const params = useSearchParams();
-
+  const { showToast } = useToast();
   const locale = useMemo(
     () => (params ? params.get("locale") : null),
     [params]
@@ -46,36 +47,38 @@ export const Form: React.FC<Props> = ({
     defaultValues: fields.reduce(
       (acc, curr) => ({ ...acc, [curr.name]: curr.value }),
       {}
-    ),
+    )
   });
 
-  const onSubmit = form.handleSubmit(async (data) => {
+  const onSubmit = form.handleSubmit(async data => {
     const depopulatedData = getObjectWithDepopulatedReferences(data);
 
     const res = await fetch(`${endpoint}${locale ? `?locale=${locale}` : ""}`, {
       method,
-      body: JSON.stringify(depopulatedData),
+      body: JSON.stringify(depopulatedData)
     });
 
     if (!res.ok) {
+      showToast({ title: "Something went wrong. Try again", type: "error" });
       throw new Error("Bad server response:" + res.status);
     }
+    showToast({ title: "Operation completed", type: "success" });
   });
 
   const liveData = form.watch();
 
   return (
-    <div className="flex h-full relative">
+    <div className="relative flex h-full">
       <div
         className={clsx(
-          "flex flex-col relative p-16 bg-gray-100 w-full",
+          "relative flex w-full flex-col bg-gray-100 p-16",
           previewUrl && "max-w-lg"
         )}
       >
-        <h1 className="text-red-600 font-black text-4xl mb-8 uppercase">
+        <h1 className="mb-8 text-4xl font-black uppercase text-red-600">
           {title}
         </h1>
-        <form onSubmit={onSubmit} className="relative flex flex-col gap-4">
+        <form onSubmit={onSubmit} className=" flex flex-col gap-4">
           <FormElements form={form} fields={fields} />
           <Button className="mt-4" type="submit">
             {submitText}

--- a/packages/catalyst/src/dashboard/hooks/useToast.tsx
+++ b/packages/catalyst/src/dashboard/hooks/useToast.tsx
@@ -1,0 +1,41 @@
+import { ToastType } from "../_shared/Toast/types";
+import { Toast, ToastProps } from "../_shared/Toast/Toast";
+import { ToastPosition, toast } from "react-toastify";
+import clsx from "clsx";
+
+export type ToastContent = {
+  type: ToastType;
+  title: string;
+  message?: string;
+};
+
+type ShowToastAttributes = ToastProps & { position?: ToastPosition };
+const containerStyleMap: Record<ToastType, string> = {
+  success: "!border-green-500",
+  error: "!border-red-500",
+  warning: "!border-yellow-500",
+  info: "!border-blue-500"
+};
+
+export function useToast() {
+  function showToast({
+    position = "bottom-right",
+    ...toastProps
+  }: ShowToastAttributes) {
+    const selectedStyle = containerStyleMap[toastProps.type];
+
+    toast(<Toast {...toastProps} />, {
+      position,
+      className: clsx(
+        "!p-2 bg-gray-50 drop-shadow-lg border-l-8",
+        selectedStyle
+      ),
+      hideProgressBar: true,
+      autoClose: 2500
+    });
+  }
+
+  return {
+    showToast
+  };
+}

--- a/packages/catalyst/src/dashboard/index.tsx
+++ b/packages/catalyst/src/dashboard/index.tsx
@@ -9,6 +9,7 @@ import { LogoutRoute } from "./routes/logout";
 import { EditCollectionRoute } from "./routes/editCollection";
 import { EditGlobalRoute } from "./routes/editGlobal";
 import { ForbiddenRoute } from "./routes/forbidden";
+import { ToastProvider } from "./_shared/Toast/ToastProvider";
 import "./__generated.css";
 
 const ROUTE_MAP: Record<
@@ -50,7 +51,7 @@ export function createDashboard(cms: CatalystCms, config: CatalystConfig) {
     const RouteComponent = ROUTE_MAP[matchedRoute] || notFound();
 
     return (
-      <div className="w-full h-full overflow-y-auto bg-gray-100">
+      <div className="h-full w-full overflow-y-auto bg-gray-100">
         {/* @ts-expect-error Server Components */}
         <RouteComponent
           cms={cms}
@@ -59,6 +60,7 @@ export function createDashboard(cms: CatalystCms, config: CatalystConfig) {
           session={session}
           searchParams={searchParams}
         />
+        <ToastProvider />
       </div>
     );
   };

--- a/packages/catalyst/src/uno.config.ts
+++ b/packages/catalyst/src/uno.config.ts
@@ -1,5 +1,0 @@
-import { defineConfig, presetTypography, presetUno } from "unocss";
-
-export default defineConfig({
-  presets: [presetUno(), presetTypography()]
-});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -10,6 +10,9 @@ importers:
       prettier:
         specifier: ^2.8.8
         version: 2.8.8
+      prettier-plugin-tailwindcss:
+        specifier: ^0.2.8
+        version: 0.2.8(prettier@2.8.8)
       turbo:
         specifier: latest
         version: 1.9.3
@@ -113,6 +116,9 @@ importers:
       react-hook-form:
         specifier: ^7.43.9
         version: 7.43.9(react@18.2.0)
+      react-toastify:
+        specifier: ^9.1.2
+        version: 9.1.2(react-dom@18.2.0)(react@18.2.0)
       wretch:
         specifier: ^2.5.2
         version: 2.5.2
@@ -2893,6 +2899,58 @@ packages:
     engines: {node: '>= 0.8.0'}
     dev: true
 
+  /prettier-plugin-tailwindcss@0.2.8(prettier@2.8.8):
+    resolution: {integrity: sha512-KgPcEnJeIijlMjsA6WwYgRs5rh3/q76oInqtMXBA/EMcamrcYJpyhtRhyX1ayT9hnHlHTuO8sIifHF10WuSDKg==}
+    engines: {node: '>=12.17.0'}
+    peerDependencies:
+      '@ianvs/prettier-plugin-sort-imports': '*'
+      '@prettier/plugin-pug': '*'
+      '@shopify/prettier-plugin-liquid': '*'
+      '@shufo/prettier-plugin-blade': '*'
+      '@trivago/prettier-plugin-sort-imports': '*'
+      prettier: '>=2.2.0'
+      prettier-plugin-astro: '*'
+      prettier-plugin-css-order: '*'
+      prettier-plugin-import-sort: '*'
+      prettier-plugin-jsdoc: '*'
+      prettier-plugin-organize-attributes: '*'
+      prettier-plugin-organize-imports: '*'
+      prettier-plugin-style-order: '*'
+      prettier-plugin-svelte: '*'
+      prettier-plugin-twig-melody: '*'
+    peerDependenciesMeta:
+      '@ianvs/prettier-plugin-sort-imports':
+        optional: true
+      '@prettier/plugin-pug':
+        optional: true
+      '@shopify/prettier-plugin-liquid':
+        optional: true
+      '@shufo/prettier-plugin-blade':
+        optional: true
+      '@trivago/prettier-plugin-sort-imports':
+        optional: true
+      prettier-plugin-astro:
+        optional: true
+      prettier-plugin-css-order:
+        optional: true
+      prettier-plugin-import-sort:
+        optional: true
+      prettier-plugin-jsdoc:
+        optional: true
+      prettier-plugin-organize-attributes:
+        optional: true
+      prettier-plugin-organize-imports:
+        optional: true
+      prettier-plugin-style-order:
+        optional: true
+      prettier-plugin-svelte:
+        optional: true
+      prettier-plugin-twig-melody:
+        optional: true
+    dependencies:
+      prettier: 2.8.8
+    dev: true
+
   /prettier@2.8.8:
     resolution: {integrity: sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q==}
     engines: {node: '>=10.13.0'}
@@ -3095,6 +3153,17 @@ packages:
 
   /react-is@16.13.1:
     resolution: {integrity: sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==}
+
+  /react-toastify@9.1.2(react-dom@18.2.0)(react@18.2.0):
+    resolution: {integrity: sha512-PBfzXO5jMGEtdYR5jxrORlNZZe/EuOkwvwKijMatsZZm8IZwLj01YvobeJYNjFcA6uy6CVrx2fzL9GWbhWPTDA==}
+    peerDependencies:
+      react: '>=16'
+      react-dom: '>=16'
+    dependencies:
+      clsx: 1.2.1
+      react: 18.2.0
+      react-dom: 18.2.0(react@18.2.0)
+    dev: false
 
   /react@18.2.0:
     resolution: {integrity: sha512-/3IjMdb2L9QbBdWiW5e3P2/npwMBaU9mHCSCUzNln0ZCYbcfTsGbTJrU/kGemdH2IWmB2ioZ+zkxtmq6g09fGQ==}


### PR DESCRIPTION
# Proposed changes

Added toast creating/updating types
In addition, `prettier-plugin-tailwindcss` has been added 
closes #6

## Types of changes

- [ ] 🐛 Bugfix (non-breaking change which fixes an issue)
- [X] ✨ New feature (non-breaking change which adds functionality or enhancements)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] ✅ Tests (added tests for an existing feature)
- [ ] 📚 Documentation Update (if none of the other choices apply)
- [ ] 🙌 Other (please, write a clear and concise description of the proposal in the section above)

## Checklist

- [X] 👀 I have read the [README](https://github.com/VLK-STUDIO/catalyst-cms/blob/main/README.md) doc
- [X] ✅ Lint pass locally with my changes
- [X] 📚 I have added the necessary documentation (if appropriate)
- [X] 🔀 Any dependent changes have been merged and published in downstream modules

## Further comments

It has been added all the configurations to initialize and use the toast. At the moment, they can be triggered with the hook `useToast` that allows it to display the contents that are passed. 

```typescript
showToast({ title: "Operation completed", type: "success" });
```
